### PR TITLE
fix(ci): use trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,4 @@ jobs:
       - name: Publish package
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISHER_TOKEN }}
         run: CI=true npm run semantic-release


### PR DESCRIPTION
- https://docs.npmjs.com/trusted-publishers
- https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions#trusted-publishing-and-npm-provenance

---

- [x] I've configured trusted publishing in the package settings: https://www.npmjs.com/package/escher-keypool/access